### PR TITLE
修改scanner::scanWord以正常解析

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -210,6 +210,10 @@ func (s *scanner) scanWord() token {
 		if unicode.IsSpace(r) {
 			break
 		}
+		if r == '{' {
+			s.unread()
+			break
+		}
 		if r == ';' {
 			s.unread()
 			break


### PR DESCRIPTION
使指令和{之间无空格的配置可以正确解析